### PR TITLE
Fixed LeftNav not saving state after navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { ConfigProvider } from 'antd';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import './App.scss';
+import { AppContextProvider } from './AppContext';
 import Chat from './pages/chat/Chat';
 import Dashboard from './pages/dashboard/Dashboard';
 import Settings from './pages/settings/Settings';
@@ -22,6 +23,7 @@ function App() {
         },
       }}
     >
+      <AppContextProvider>
       <Routes>
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/workflows" element={<Workflows />} />
@@ -29,6 +31,7 @@ function App() {
           <Route path="/settings" element={<Settings />} />
           <Route path="/" element={<Navigate to="/dashboard" />} />
        </Routes>
+       </AppContextProvider>
     </ConfigProvider>
   );
 }

--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useState } from 'react'
+import { AppContextProps } from './AppContextProps';
+
+const defaultContext = {
+    collapsed: false,
+    toggleCollapsed: () => {}
+}
+
+const AppContext = createContext(defaultContext);
+
+export function AppContextProvider( props: AppContextProps ){
+const [collapsed, setCollapsed] = useState(false);
+
+function toggleCollapsed(){
+    setCollapsed(!collapsed);
+}
+
+return <AppContext.Provider value={{collapsed, toggleCollapsed}}>{props.children}</AppContext.Provider>
+
+}
+
+
+export default AppContext

--- a/src/AppContextProps.ts
+++ b/src/AppContextProps.ts
@@ -1,0 +1,3 @@
+export interface AppContextProps{
+    children: React.ReactNode;
+}

--- a/src/components/layouts/DashboardLayout.tsx
+++ b/src/components/layouts/DashboardLayout.tsx
@@ -2,13 +2,15 @@ import { MenuFoldOutlined, MenuUnfoldOutlined } from '@ant-design/icons';
 import { theme } from 'antd';
 import Layout, { Content, Header } from 'antd/es/layout/layout';
 import Sider from 'antd/es/layout/Sider';
-import React, { useState } from 'react';
+import React, { useContext } from 'react';
+import AppContext from '../../AppContext';
 import LeftNav from '../left-nav/LeftNav';
 import './DashboardLayout.scss'
 import { DashboardLayoutProps } from './DashboardLayoutProps';
 
 const DashboardLayout: React.FunctionComponent<DashboardLayoutProps> = (props: DashboardLayoutProps) => {
-    const [collapsed, setCollapsed] = useState(false);
+    const {collapsed} = useContext(AppContext);
+    const {toggleCollapsed} = useContext(AppContext);
     const {
         token: { colorBgContainer },
     } = theme.useToken();
@@ -22,7 +24,7 @@ const DashboardLayout: React.FunctionComponent<DashboardLayoutProps> = (props: D
                 <Header style={{ padding: 0, paddingLeft: 20, background: colorBgContainer }}>
                     {React.createElement(collapsed ? MenuUnfoldOutlined : MenuFoldOutlined, {
                         className: 'trigger',
-                        onClick: () => setCollapsed(!collapsed),
+                        onClick: toggleCollapsed,
                     })}
                 </Header>
                 <Content

--- a/src/components/left-nav/link-list/LinkList.tsx
+++ b/src/components/left-nav/link-list/LinkList.tsx
@@ -3,6 +3,7 @@ import { LineChartOutlined, ThunderboltOutlined, MessageOutlined, SettingOutline
 import type { MenuProps } from 'antd';
 import { Menu } from 'antd';
 import './LinkList.scss';
+import { Link } from 'react-router-dom';
 
 type MenuItem = Required<MenuProps>['items'][number];
 
@@ -14,10 +15,10 @@ class LinkList extends React.Component {
     constructor() {
         super({});
         this.items = [
-            this.getItem(<a href="/dashboard">Dashboard</a>, 'dashboard', <LineChartOutlined />),
-            this.getItem(<a href="/workflows">Workflows</a>, 'workflows', <ThunderboltOutlined />),
-            this.getItem(<a href="/chat">Chat</a>, 'chat', <MessageOutlined />),
-            this.getItem(<a href="/settings">Settings</a>, 'settings', <SettingOutlined />)
+            this.getItem(<Link to="/dashboard">Dashboard</Link>, 'dashboard', <LineChartOutlined />),
+            this.getItem(<Link to="/workflows">Workflows</Link>, 'workflows', <ThunderboltOutlined />),
+            this.getItem(<Link to="/chat">Chat</Link>, 'chat', <MessageOutlined />),
+            this.getItem(<Link to="/settings">Settings</Link>, 'settings', <SettingOutlined />)
         ];
     }
     /**


### PR DESCRIPTION
Fixes #18 

Summary of changes:

- Created AppContext
- Moved collapsed state into AppContext
- Wrapped AppContextProvider around Routes
- Swapped <a> tags for <Link>

Effect: The left nav state remains consistent between navigation