### PR TITLE
Fixed leftnav option not staying selected after page navigation

### DIFF
--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -3,19 +3,25 @@ import { AppContextProps } from './AppContextProps';
 
 const defaultContext = {
     collapsed: false,
-    toggleCollapsed: () => {}
+    toggleCollapsed: () => {},
+    selectedMenuItem: 'dashboard',
+    setSelectedMenuItem: (key: string) => {}
 }
 
 const AppContext = createContext(defaultContext);
 
 export function AppContextProvider( props: AppContextProps ){
 const [collapsed, setCollapsed] = useState(false);
+const [selectedMenuItem, setSelectedMenuItem] = useState('dashboard');
 
 function toggleCollapsed(){
     setCollapsed(!collapsed);
 }
 
-return <AppContext.Provider value={{collapsed, toggleCollapsed}}>{props.children}</AppContext.Provider>
+return <AppContext.Provider 
+            value={{collapsed, toggleCollapsed, selectedMenuItem, setSelectedMenuItem}}>
+            {props.children}
+        </AppContext.Provider>
 
 }
 

--- a/src/components/left-nav/LeftNav.tsx
+++ b/src/components/left-nav/LeftNav.tsx
@@ -11,7 +11,7 @@ const LeftNav: React.FunctionComponent<LeftNavProps> = (props: LeftNavProps) => 
     return <>
         <div className="left-nav bg-primary-gradient">
             <UserCard collapsed={props.collapsed} />
-            <LinkList />
+            <LinkList> </LinkList>
         </div>
     </>
 }

--- a/src/components/left-nav/link-list/LinkList.tsx
+++ b/src/components/left-nav/link-list/LinkList.tsx
@@ -4,37 +4,44 @@ import type { MenuProps } from 'antd';
 import { Menu } from 'antd';
 import './LinkList.scss';
 import { Link } from 'react-router-dom';
+import { useContext } from 'react';
+import AppContext from '../../../AppContext';
+import { LinkListProps } from './LinkListProps';
 
 type MenuItem = Required<MenuProps>['items'][number];
 
 /**
  * Defines the user card component.
  */
-class LinkList extends React.Component {
-    items: MenuItem[];
-    constructor() {
-        super({});
-        this.items = [
-            this.getItem(<Link to="/dashboard">Dashboard</Link>, 'dashboard', <LineChartOutlined />),
-            this.getItem(<Link to="/workflows">Workflows</Link>, 'workflows', <ThunderboltOutlined />),
-            this.getItem(<Link to="/chat">Chat</Link>, 'chat', <MessageOutlined />),
-            this.getItem(<Link to="/settings">Settings</Link>, 'settings', <SettingOutlined />)
+const LinkList: React.FunctionComponent<LinkListProps> = (props: LinkListProps) => {
+    const {selectedMenuItem} = useContext(AppContext);
+    const {setSelectedMenuItem} = useContext(AppContext);
+    const items: MenuItem[] = [
+        getItem(<Link onClick={() => setSelectedMenuItem('dashboard')} to="/dashboard">Dashboard</Link>,
+                'dashboard', <LineChartOutlined />),
+        getItem(<Link onClick={() => setSelectedMenuItem('workflows')} to="/workflows">Workflows</Link>,
+                'workflows', <ThunderboltOutlined />),
+        getItem(<Link onClick={() => setSelectedMenuItem('chat')} to="/chat">Chat</Link>,
+                'chat', <MessageOutlined />),
+        getItem(<Link onClick={() => setSelectedMenuItem('settings')} to="/settings">Settings</Link>,
+                'settings', <SettingOutlined />)
         ];
-    }
+        
     /**
      * Renders the user card component.
      * @returns The user card component.
      * @override
      */
-    override render() {
+    
+        
         return (
             <Menu className="link-list"
                 mode="vertical"
-                items={this.items}
+                items={items}
+                defaultSelectedKeys={[selectedMenuItem]}
             />
         );
-    }
-    private getItem(
+     function getItem(
         label: React.ReactNode,
         key: React.Key,
         icon?: React.ReactNode,

--- a/src/components/left-nav/link-list/LinkListProps.ts
+++ b/src/components/left-nav/link-list/LinkListProps.ts
@@ -1,0 +1,3 @@
+export interface LinkListProps {
+    children: React.ReactNode;
+}


### PR DESCRIPTION
Fixes #17 

Summary of changes:

- Added selectedMenuItem to context
- Made LinkList a ReactFC instead of a class
- defaultSelectedKeys prop now uses selectedMenuItem from context to set which menu item is selected
